### PR TITLE
fix image float problem on smaller screens

### DIFF
--- a/_sass/_tabs.scss
+++ b/_sass/_tabs.scss
@@ -70,6 +70,14 @@ input:checked + label {
 
 
 @include media(">real-big") {
+
+}
+
+@include media(">large", "<=real-big") {
+
+}
+
+@include media(">small", "<=large")  {
   label {
     font-size: 0;
   }
@@ -79,16 +87,12 @@ input:checked + label {
   }
 }
 
-@include media(">large", "<=real-big") {
-  label {
-    padding: 15px;
-  }
-}
-
-@include media(">small", "<=large")  {
-
-}
-
 @include media("<=small")  {
-
+  label {
+    font-size: 0;
+  }
+  label:before {
+    margin: 0;
+    font-size: 18px;
+  }
 }

--- a/_sass/_tabs.scss
+++ b/_sass/_tabs.scss
@@ -1,3 +1,5 @@
+$breakpoints: (small: 480px, medium: 768px, large: 1024px, big: 1198px, real-big: 1400px);
+
 *, *:before, *:after {
   margin: 0;
   padding: 0;
@@ -59,8 +61,15 @@ input:checked + label {
   padding: 2em 2em 0 2em;
 }
 
+.prod-image .device.iphone {
+  margin: 0px;
+  position: relative;
+  top: 0px;
+  left: 0px;
+}
 
-@media screen and (max-width: 650px) {
+
+@include media(">real-big") {
   label {
     font-size: 0;
   }
@@ -70,8 +79,16 @@ input:checked + label {
   }
 }
 
-@media screen and (max-width: 400px) {
+@include media(">large", "<=real-big") {
   label {
     padding: 15px;
   }
+}
+
+@include media(">small", "<=large")  {
+
+}
+
+@include media("<=small")  {
+
 }

--- a/curriculum.md
+++ b/curriculum.md
@@ -25,7 +25,7 @@ permalink: /curriculum/
       {% for grade7 in site.curriculum.grade7 %}
         <div class="concepts">
           <div class="prod-image">
-            <div class="device iphone">
+            <div class=" device iphone">
                 <img src="./../assets/images/product_features/iphone.png">
                 <div class="screen" >
                   <img src="{{ site.baseurl }}/{{grade7.image}}"/>
@@ -137,7 +137,7 @@ permalink: /curriculum/
     <div class="hero__content">
       <h3>Download the Free Ardor Math App!</h3>
       <p>
-        The problems shown above are only a sample. Download the free app to see what Ardor has to offer. 
+        The problems shown above are only a sample. Download the free app to see what Ardor has to offer.
       </p>
       <div id="sub-area">
           <div class="badge-area">


### PR DESCRIPTION
quick fix for smaller screens. This fix stops the image from popping over the text. 
more work will still need to be done to clean up phone screen sizes. 